### PR TITLE
fix: disposal crash

### DIFF
--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -620,6 +620,9 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Returns a widget showing a live camera preview.
   Widget buildPreview() {
+    if (_isDisposed) {
+      return SizedBox.expand(child: Container(color: Colors.black));
+    }
     _throwIfNotInitialized('buildPreview');
     try {
       return CameraPlatform.instance.buildPreview(_cameraId);


### PR DESCRIPTION
Rather than crash the app, show black box when a draw occurs during an ongoing camera disposal 

https://console.firebase.google.com/u/0/project/sbs-diet-app/crashlytics/app/ios:com.sbs.diet/issues/5437bea31812b134cd4e29d2d860004d?time=last-seven-days&types=crash&sessionEventKey=cb3e7e73212245f0825059f924926c34_2004194367106619749&subIssues=367b2fb51d04ea07cc2052e8b27f9975