### PR TITLE
fix: avoid wide color gamut crash

### DIFF
--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
@@ -346,6 +346,7 @@ NSString *const errorMethod = @"error";
 }
 
 - (BOOL)setCaptureSessionPreset:(FLTResolutionPreset)resolutionPreset withError:(NSError **)error {
+  _videoCaptureSession.automaticallyConfiguresCaptureDeviceForWideColor = false;
   switch (resolutionPreset) {
     case FLTResolutionPresetMax:
     case FLTResolutionPresetUltraHigh:


### PR DESCRIPTION
Prospective workaround to crashes flagged in chat based on a [similar recent workaround report](https://github.com/mrousavy/react-native-vision-camera/issues/2892). Loss: slightly less amazing out-of-sRGB-spectrum color.

https://developer.apple.com/documentation/avfoundation/avcapturesession/1648764-automaticallyconfigurescapturede?language=objc